### PR TITLE
Add JSCAD Assembler UI: HTML, CSS and bundled JS runtime

### DIFF
--- a/assembler.css
+++ b/assembler.css
@@ -50,35 +50,35 @@ body {
 }
 
 #asmAddBtn {
-  background: #5f8060;
-  border-color: #4f6e50;
-  color: #fff;
+  background: #5f8060 !important;
+  border-color: #4f6e50 !important;
+  color: #fff !important;
 }
 
 #asmDuplicateBtn {
-  background: #607a96;
-  border-color: #4f6884;
-  color: #fff;
+  background: #607a96 !important;
+  border-color: #4f6884 !important;
+  color: #fff !important;
 }
 
 #asmRemoveBtn,
 #asmClearBtn {
-  background: #8e5d5d;
-  border-color: #7a4f4f;
-  color: #fff;
+  background: #8e5d5d !important;
+  border-color: #7a4f4f !important;
+  color: #fff !important;
 }
 
 #asmAddBtn:hover {
-  background: #567557;
+  background: #567557 !important;
 }
 
 #asmDuplicateBtn:hover {
-  background: #576f8a;
+  background: #576f8a !important;
 }
 
 #asmRemoveBtn:hover,
 #asmClearBtn:hover {
-  background: #805353;
+  background: #805353 !important;
 }
 
 .asm-toolbar-logo {

--- a/assembler.css
+++ b/assembler.css
@@ -1,0 +1,340 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, Arial, sans-serif;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+}
+
+#asmApp {
+  height: 100vh;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #f5f6f8;
+  color: #10131a;
+}
+
+#asmToolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid #d7dbe2;
+  background: #fff;
+}
+
+#asmToolbar button {
+  padding: 7px 12px;
+  border: 1px solid #c7cedb;
+  background: #ffffff;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#asmToolbar button:hover {
+  background: #f2f5fb;
+}
+
+.asm-toolbar-logo {
+  margin-left: auto;
+  width: 250px;
+  height: 35px;
+  object-fit: contain;
+  max-width: 100%;
+}
+
+#asmLayout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(300px, 380px);
+  gap: 12px;
+  padding: 12px;
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+#asmCatalog,
+#asmInspector,
+#asmViewerPanel {
+  background: #fff;
+  border: 1px solid #d7dbe2;
+  border-radius: 8px;
+  padding: 10px;
+  min-height: 0;
+}
+
+#asmCatalog,
+#asmInspector {
+  overflow: auto;
+}
+
+#asmCatalogHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+#asmCatalogHeader h2 {
+  margin: 0;
+}
+
+#asmCatalogToggle {
+  border: 1px solid #c7cedb;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+#asmCatalog.is-collapsed #asmCatalogList {
+  display: none;
+}
+
+#asmViewerPanel {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#asmViewer {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  width: 100%;
+  border: 1px solid #d8dde8;
+  border-radius: 6px;
+  background: #f0f3f8;
+}
+
+#asmCatalogList,
+#asmPieceList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#asmCatalogList li,
+#asmPieceList li {
+  border: 1px solid #d7dbe2;
+  border-radius: 6px;
+  padding: 7px;
+  cursor: pointer;
+  background: #fff;
+}
+
+#asmCatalogList li:hover,
+#asmPieceList li:hover {
+  border-color: #8ca4d5;
+}
+
+#asmCatalogList li.is-selected,
+#asmPieceList li.is-selected {
+  border-color: #3a67c7;
+  background: #eaf0ff;
+}
+
+#asmCatalogList li.asm-divider {
+  border: 0;
+  border-top: 1px solid #d7dbe2;
+  border-radius: 0;
+  height: 0;
+  padding: 0;
+  margin: 4px 2px;
+  cursor: default;
+  background: transparent;
+}
+
+.asm-catalog-item-title {
+  display: inline;
+}
+
+.asm-new-badge,
+.asm-type-badge {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 6px;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+
+.asm-new-badge {
+  background: #ffd54f;
+  color: #2f2700;
+  font-weight: 700;
+}
+
+.asm-type-badge {
+  background: #e8edf7;
+  color: #3f4c66;
+}
+
+#asmPieceList li.is-loading::after {
+  content: " • loading";
+  color: #745700;
+  font-size: 12px;
+}
+
+#asmPieceList li.is-error::after {
+  content: " • error";
+  color: #b11a1a;
+  font-size: 12px;
+}
+
+#asmAssembly {
+  margin-top: 12px;
+}
+
+#asmAssembly h2 {
+  margin: 0 0 8px 0;
+}
+
+#asmInspectorHeader {
+  margin-bottom: 6px;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+#asmPartIdWrap {
+  margin-bottom: 8px;
+}
+
+#asmPartIdWrap label {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+#asmPartIdInput {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 5px 6px;
+}
+
+#asmTransformForm {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.asm-transform-group {
+  border: 1px solid #dbe1ee;
+  border-radius: 8px;
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.asm-transform-group legend {
+  padding: 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #3f4c66;
+}
+
+.asm-transform-group label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.asm-transform-group input {
+  padding: 4px 6px;
+}
+
+.asm-axis {
+  font-weight: 700;
+}
+
+.asm-axis-x {
+  color: #d91f1f;
+}
+
+.asm-axis-y {
+  color: #108f35;
+}
+
+.asm-axis-z {
+  color: #2359d4;
+}
+
+.asm-group-block {
+  border: 1px solid #dbe1ee;
+  border-radius: 8px;
+  padding: 8px;
+  margin: 10px 0 0 0;
+}
+
+.asm-group-block legend {
+  padding: 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #3f4c66;
+}
+
+#asmParams {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.asm-param,
+.asm-group {
+  margin-bottom: 10px;
+}
+
+.asm-param label,
+.asm-group-title {
+  font-size: 13px;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.asm-param input,
+.asm-param select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 6px;
+}
+
+#asmPieceStatus,
+#asmParams {
+  min-height: 20px;
+  font-size: 13px;
+}
+
+#asmPieceStatus {
+  margin-top: 4px;
+}
+
+#asmPieceStatus.is-error {
+  color: #b11a1a;
+}
+
+#asmPieceStatus.is-info {
+  color: #1c4a9d;
+}
+
+@media (max-width: 1280px) {
+  #asmLayout {
+    grid-template-columns: 260px minmax(0, 1fr) 300px;
+  }
+}

--- a/assembler.css
+++ b/assembler.css
@@ -50,35 +50,35 @@ body {
 }
 
 #asmAddBtn {
-  background: #d7e4d5;
-  border-color: #a7bca3;
-  color: #284626;
+  background: #5f8060;
+  border-color: #4f6e50;
+  color: #fff;
 }
 
 #asmDuplicateBtn {
-  background: #d8e1ee;
-  border-color: #aab8cd;
-  color: #24405c;
+  background: #607a96;
+  border-color: #4f6884;
+  color: #fff;
 }
 
 #asmRemoveBtn,
 #asmClearBtn {
-  background: #ecd9d9;
-  border-color: #cfaaaa;
-  color: #6b2f2f;
+  background: #8e5d5d;
+  border-color: #7a4f4f;
+  color: #fff;
 }
 
 #asmAddBtn:hover {
-  background: #c9dbc6;
+  background: #567557;
 }
 
 #asmDuplicateBtn:hover {
-  background: #ccd8e8;
+  background: #576f8a;
 }
 
 #asmRemoveBtn:hover,
 #asmClearBtn:hover {
-  background: #e4cccc;
+  background: #805353;
 }
 
 .asm-toolbar-logo {

--- a/assembler.css
+++ b/assembler.css
@@ -28,7 +28,15 @@ body {
   background: #fff;
 }
 
-#asmToolbar button {
+#asmToolbarControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+#asmToolbar button,
+.asm-panel-btn {
   padding: 7px 12px;
   border: 1px solid #c7cedb;
   background: #ffffff;
@@ -36,7 +44,8 @@ body {
   cursor: pointer;
 }
 
-#asmToolbar button:hover {
+#asmToolbar button:hover,
+.asm-panel-btn:hover {
   background: #f2f5fb;
 }
 
@@ -59,6 +68,18 @@ body {
   overflow: hidden;
 }
 
+#asmLayout.is-catalog-hidden {
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 380px);
+}
+
+#asmLayout.is-inspector-hidden {
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+}
+
+#asmLayout.is-catalog-hidden.is-inspector-hidden {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 #asmCatalog,
 #asmInspector,
 #asmViewerPanel {
@@ -74,6 +95,14 @@ body {
   overflow: auto;
 }
 
+#asmLayout.is-catalog-hidden #asmCatalog {
+  display: none;
+}
+
+#asmLayout.is-inspector-hidden #asmInspector {
+  display: none;
+}
+
 #asmCatalogHeader {
   display: flex;
   align-items: center;
@@ -86,17 +115,17 @@ body {
   margin: 0;
 }
 
-#asmCatalogToggle {
+#asmCatalogToggle,
+#asmHidePanelsBtn,
+#asmShowLeftPanelBtn,
+#asmDeselectBtn,
+#asmInspectorCloseBtn {
   border: 1px solid #c7cedb;
   border-radius: 6px;
   background: #fff;
   cursor: pointer;
   font-size: 12px;
   padding: 4px 8px;
-}
-
-#asmCatalog.is-collapsed #asmCatalogList {
-  display: none;
 }
 
 #asmViewerPanel {
@@ -204,20 +233,29 @@ body {
   margin: 0 0 8px 0;
 }
 
-#asmInspectorHeader {
-  margin-bottom: 6px;
-  font-weight: 600;
-  word-break: break-word;
-}
-
-#asmPartIdWrap {
+#asmAssemblyHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   margin-bottom: 8px;
 }
 
-#asmPartIdWrap label {
-  display: block;
-  font-size: 12px;
-  margin-bottom: 4px;
+#asmAssemblyHeader h2 {
+  margin: 0;
+}
+
+#asmInspectorHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+#asmInspectorHeader {
+  font-weight: 600;
+  word-break: break-word;
 }
 
 #asmPartIdInput {
@@ -336,5 +374,9 @@ body {
 @media (max-width: 1280px) {
   #asmLayout {
     grid-template-columns: 260px minmax(0, 1fr) 300px;
+  }
+
+  #asmLayout.is-catalog-hidden {
+    grid-template-columns: minmax(0, 1fr) 300px;
   }
 }

--- a/assembler.css
+++ b/assembler.css
@@ -49,6 +49,38 @@ body {
   background: #f2f5fb;
 }
 
+#asmAddBtn {
+  background: #d7e4d5;
+  border-color: #a7bca3;
+  color: #284626;
+}
+
+#asmDuplicateBtn {
+  background: #d8e1ee;
+  border-color: #aab8cd;
+  color: #24405c;
+}
+
+#asmRemoveBtn,
+#asmClearBtn {
+  background: #ecd9d9;
+  border-color: #cfaaaa;
+  color: #6b2f2f;
+}
+
+#asmAddBtn:hover {
+  background: #c9dbc6;
+}
+
+#asmDuplicateBtn:hover {
+  background: #ccd8e8;
+}
+
+#asmRemoveBtn:hover,
+#asmClearBtn:hover {
+  background: #e4cccc;
+}
+
 .asm-toolbar-logo {
   margin-left: auto;
   width: 250px;
@@ -68,15 +100,11 @@ body {
   overflow: hidden;
 }
 
-#asmLayout.is-catalog-hidden {
-  grid-template-columns: minmax(0, 1fr) minmax(300px, 380px);
-}
-
 #asmLayout.is-inspector-hidden {
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
 }
 
-#asmLayout.is-catalog-hidden.is-inspector-hidden {
+#asmLayout.is-panels-hidden {
   grid-template-columns: minmax(0, 1fr);
 }
 
@@ -95,11 +123,12 @@ body {
   overflow: auto;
 }
 
-#asmLayout.is-catalog-hidden #asmCatalog {
+#asmLayout.is-panels-hidden #asmCatalog {
   display: none;
 }
 
-#asmLayout.is-inspector-hidden #asmInspector {
+#asmLayout.is-inspector-hidden #asmInspector,
+#asmLayout.is-panels-hidden #asmInspector {
   display: none;
 }
 
@@ -117,7 +146,6 @@ body {
 
 #asmCatalogToggle,
 #asmHidePanelsBtn,
-#asmShowLeftPanelBtn,
 #asmDeselectBtn,
 #asmInspectorCloseBtn {
   border: 1px solid #c7cedb;
@@ -126,6 +154,10 @@ body {
   cursor: pointer;
   font-size: 12px;
   padding: 4px 8px;
+}
+
+#asmCatalog.is-catalog-collapsed #asmCatalogList {
+  display: none;
 }
 
 #asmViewerPanel {
@@ -353,6 +385,22 @@ body {
   padding: 4px 6px;
 }
 
+.asm-param-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.asm-param-checkbox input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+
+.asm-param-checkbox label {
+  margin: 0;
+  display: inline;
+}
+
 #asmPieceStatus,
 #asmParams {
   min-height: 20px;
@@ -376,7 +424,7 @@ body {
     grid-template-columns: 260px minmax(0, 1fr) 300px;
   }
 
-  #asmLayout.is-catalog-hidden {
-    grid-template-columns: minmax(0, 1fr) 300px;
+  #asmLayout.is-inspector-hidden {
+    grid-template-columns: 260px minmax(0, 1fr);
   }
 }

--- a/assembler.html
+++ b/assembler.html
@@ -11,12 +11,17 @@
 <body>
   <div id="asmApp">
     <div id="asmToolbar">
-      <button id="asmAddBtn" type="button">Add</button>
-      <button id="asmDuplicateBtn" type="button">Duplicate</button>
-      <button id="asmRemoveBtn" type="button">Remove</button>
-      <button id="asmExportBtn" type="button">Export JSON</button>
-      <button id="asmImportBtn" type="button">Import JSON</button>
-      <button id="asmClearBtn" type="button">Clear</button>
+      <div id="asmToolbarControls">
+        <button id="asmCatalogToggle" type="button" aria-expanded="true">Close Catalog</button>
+        <button id="asmHidePanelsBtn" type="button">Hide Panels</button>
+        <button id="asmShowLeftPanelBtn" type="button" hidden>Show Left Panel</button>
+        <button id="asmAddBtn" type="button">Add</button>
+        <button id="asmDuplicateBtn" type="button">Duplicate</button>
+        <button id="asmRemoveBtn" type="button">Remove</button>
+        <button id="asmExportBtn" type="button">Export JSON</button>
+        <button id="asmImportBtn" type="button">Import JSON</button>
+        <button id="asmClearBtn" type="button">Clear</button>
+      </div>
       <img class="asm-toolbar-logo" src="imgs/title.png" alt="Mobility Shield">
     </div>
 
@@ -24,11 +29,13 @@
       <aside id="asmCatalog">
         <div id="asmCatalogHeader">
           <h2>Catalog</h2>
-          <button id="asmCatalogToggle" type="button" aria-expanded="true">Collapse</button>
         </div>
         <ul id="asmCatalogList"></ul>
         <section id="asmAssembly">
-          <h2>Assembly</h2>
+          <div id="asmAssemblyHeader">
+            <h2>Assembly</h2>
+            <button id="asmDeselectBtn" type="button">Deselect Part</button>
+          </div>
           <ul id="asmPieceList"></ul>
         </section>
       </aside>
@@ -38,11 +45,14 @@
       </section>
 
       <aside id="asmInspector">
-        <div id="asmInspectorHeader">No selection</div>
-        <div id="asmPartIdWrap">
-          <label for="asmPartIdInput">Part ID</label>
-          <input id="asmPartIdInput" type="text" autocomplete="off">
+        <div id="asmInspectorHeaderRow">
+          <div id="asmInspectorHeader">No selection</div>
+          <button id="asmInspectorCloseBtn" type="button">X</button>
         </div>
+        <fieldset id="asmPartIdWrap" class="asm-group-block">
+          <legend>Part Name</legend>
+          <input id="asmPartIdInput" type="text" autocomplete="off">
+        </fieldset>
         <form id="asmTransformForm" autocomplete="off">
           <fieldset class="asm-transform-group">
             <legend>Position</legend>

--- a/assembler.html
+++ b/assembler.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JSCAD Assembler</title>
+  <link rel="shortcut icon" href="imgs/favicon.png" type="image/x-png">
+  <link rel="stylesheet" href="openjscad.css" type="text/css">
+  <link rel="stylesheet" href="assembler.css" type="text/css">
+</head>
+<body>
+  <div id="asmApp">
+    <div id="asmToolbar">
+      <button id="asmAddBtn" type="button">Add</button>
+      <button id="asmDuplicateBtn" type="button">Duplicate</button>
+      <button id="asmRemoveBtn" type="button">Remove</button>
+      <button id="asmExportBtn" type="button">Export JSON</button>
+      <button id="asmImportBtn" type="button">Import JSON</button>
+      <button id="asmClearBtn" type="button">Clear</button>
+      <img class="asm-toolbar-logo" src="imgs/title.png" alt="Mobility Shield">
+    </div>
+
+    <div id="asmLayout">
+      <aside id="asmCatalog">
+        <div id="asmCatalogHeader">
+          <h2>Catalog</h2>
+          <button id="asmCatalogToggle" type="button" aria-expanded="true">Collapse</button>
+        </div>
+        <ul id="asmCatalogList"></ul>
+        <section id="asmAssembly">
+          <h2>Assembly</h2>
+          <ul id="asmPieceList"></ul>
+        </section>
+      </aside>
+
+      <section id="asmViewerPanel">
+        <div id="asmViewer"></div>
+      </section>
+
+      <aside id="asmInspector">
+        <div id="asmInspectorHeader">No selection</div>
+        <div id="asmPartIdWrap">
+          <label for="asmPartIdInput">Part ID</label>
+          <input id="asmPartIdInput" type="text" autocomplete="off">
+        </div>
+        <form id="asmTransformForm" autocomplete="off">
+          <fieldset class="asm-transform-group">
+            <legend>Position</legend>
+            <label><span class="asm-axis asm-axis-x">X</span> <input id="asmPosX" type="number" step="any"></label>
+            <label><span class="asm-axis asm-axis-y">Y</span> <input id="asmPosY" type="number" step="any"></label>
+            <label><span class="asm-axis asm-axis-z">Z</span> <input id="asmPosZ" type="number" step="any"></label>
+          </fieldset>
+          <fieldset class="asm-transform-group">
+            <legend>Rotation (deg)</legend>
+            <label><span class="asm-axis asm-axis-x">X</span> <input id="asmRotX" type="number" step="any"></label>
+            <label><span class="asm-axis asm-axis-y">Y</span> <input id="asmRotY" type="number" step="any"></label>
+            <label><span class="asm-axis asm-axis-z">Z</span> <input id="asmRotZ" type="number" step="any"></label>
+          </fieldset>
+        </form>
+        <fieldset id="asmParamsWrap" class="asm-group-block">
+          <legend>Part parameters</legend>
+          <div id="asmParams"></div>
+        </fieldset>
+        <fieldset id="asmPieceStatusWrap" class="asm-group-block">
+          <legend>Part status</legend>
+          <div id="asmPieceStatus"></div>
+        </fieldset>
+      </aside>
+    </div>
+
+    <input id="asmImportInput" type="file" accept=".json,application/json" hidden>
+  </div>
+
+  <script src="dist/assembler.js"></script>
+</body>
+</html>

--- a/assembler.html
+++ b/assembler.html
@@ -12,15 +12,13 @@
   <div id="asmApp">
     <div id="asmToolbar">
       <div id="asmToolbarControls">
-        <button id="asmCatalogToggle" type="button" aria-expanded="true">Close Catalog</button>
         <button id="asmHidePanelsBtn" type="button">Hide Panels</button>
-        <button id="asmShowLeftPanelBtn" type="button" hidden>Show Left Panel</button>
         <button id="asmAddBtn" type="button">Add</button>
         <button id="asmDuplicateBtn" type="button">Duplicate</button>
         <button id="asmRemoveBtn" type="button">Remove</button>
         <button id="asmExportBtn" type="button">Export JSON</button>
         <button id="asmImportBtn" type="button">Import JSON</button>
-        <button id="asmClearBtn" type="button">Clear</button>
+        <button id="asmClearBtn" type="button">Clear Assembly</button>
       </div>
       <img class="asm-toolbar-logo" src="imgs/title.png" alt="Mobility Shield">
     </div>
@@ -29,6 +27,7 @@
       <aside id="asmCatalog">
         <div id="asmCatalogHeader">
           <h2>Catalog</h2>
+          <button id="asmCatalogToggle" type="button" aria-expanded="true">Collapse</button>
         </div>
         <ul id="asmCatalogList"></ul>
         <section id="asmAssembly">

--- a/dist/assembler.js
+++ b/dist/assembler.js
@@ -13,7 +13,8 @@
   var state = {
     version: 1,
     catalog: FALLBACK_CATALOG.slice(),
-    catalogCollapsed: false,
+    catalogHidden: false,
+    panelsHidden: false,
     selectedCatalogIndex: 0,
     selectedPieceId: null,
     nextPieceCounter: 1,
@@ -86,8 +87,11 @@
     els.catalogList = document.getElementById('asmCatalogList');
     els.catalogToggle = document.getElementById('asmCatalogToggle');
     els.catalogRoot = document.getElementById('asmCatalog');
+    els.layout = document.getElementById('asmLayout');
     els.pieceList = document.getElementById('asmPieceList');
+    els.deselectBtn = document.getElementById('asmDeselectBtn');
     els.inspectorHeader = document.getElementById('asmInspectorHeader');
+    els.inspectorCloseBtn = document.getElementById('asmInspectorCloseBtn');
     els.partIdInput = document.getElementById('asmPartIdInput');
     els.params = document.getElementById('asmParams');
     els.pieceStatus = document.getElementById('asmPieceStatus');
@@ -100,6 +104,8 @@
     els.exportBtn = document.getElementById('asmExportBtn');
     els.importBtn = document.getElementById('asmImportBtn');
     els.clearBtn = document.getElementById('asmClearBtn');
+    els.hidePanelsBtn = document.getElementById('asmHidePanelsBtn');
+    els.showLeftPanelBtn = document.getElementById('asmShowLeftPanelBtn');
     els.posX = document.getElementById('asmPosX');
     els.posY = document.getElementById('asmPosY');
     els.posZ = document.getElementById('asmPosZ');
@@ -117,6 +123,10 @@
     els.importBtn.addEventListener('click', function () { els.importInput.click(); });
     els.importInput.addEventListener('change', onImportChange);
     els.catalogToggle.addEventListener('click', toggleCatalogList);
+    els.deselectBtn.addEventListener('click', deselectSelectedPiece);
+    els.inspectorCloseBtn.addEventListener('click', deselectSelectedPiece);
+    els.hidePanelsBtn.addEventListener('click', hidePanels);
+    els.showLeftPanelBtn.addEventListener('click', showLeftPanel);
     els.partIdInput.addEventListener('change', commitPartIdChange);
     els.partIdInput.addEventListener('blur', commitPartIdChange);
     els.partIdInput.addEventListener('keydown', function (event) {
@@ -298,19 +308,66 @@
   }
 
   function toggleCatalogList() {
-    state.catalogCollapsed = !state.catalogCollapsed;
-    updateCatalogCollapseUI();
+    if (state.panelsHidden) {
+      state.panelsHidden = false;
+      state.catalogHidden = false;
+    } else {
+      state.catalogHidden = !state.catalogHidden;
+    }
+    renderLayoutState();
+    scheduleViewerResize();
   }
 
-  function updateCatalogCollapseUI() {
-    if (!els.catalogRoot || !els.catalogToggle) return;
-    els.catalogRoot.classList.toggle('is-collapsed', !!state.catalogCollapsed);
-    els.catalogToggle.setAttribute('aria-expanded', state.catalogCollapsed ? 'false' : 'true');
-    els.catalogToggle.textContent = state.catalogCollapsed ? 'Expand' : 'Collapse';
+  function hidePanels() {
+    state.panelsHidden = true;
+    state.catalogHidden = true;
+    state.selectedPieceId = null;
+    renderAssemblyList();
+    renderInspector();
+    scheduleRender();
+  }
+
+  function showLeftPanel() {
+    state.panelsHidden = false;
+    state.catalogHidden = false;
+    state.selectedPieceId = null;
+    renderAssemblyList();
+    renderInspector();
+    scheduleRender();
+  }
+
+  function deselectSelectedPiece() {
+    if (!state.selectedPieceId) return;
+    state.selectedPieceId = null;
+    renderAssemblyList();
+    renderInspector();
+    scheduleRender();
+  }
+
+  function renderLayoutState() {
+    var inspectorVisible = !state.panelsHidden && !!state.selectedPieceId;
+    var catalogVisible = !state.panelsHidden && !state.catalogHidden;
+
+    els.layout.classList.toggle('is-catalog-hidden', !catalogVisible);
+    els.layout.classList.toggle('is-inspector-hidden', !inspectorVisible);
+    els.layout.classList.toggle('is-viewer-only', !catalogVisible && !inspectorVisible);
+
+    els.catalogToggle.textContent = catalogVisible ? 'Close Catalog' : 'Open Catalog';
+    els.catalogToggle.setAttribute('aria-expanded', catalogVisible ? 'true' : 'false');
+
+    var fullHidden = !!state.panelsHidden;
+    els.showLeftPanelBtn.hidden = !fullHidden;
+    els.addBtn.hidden = fullHidden;
+    els.dupBtn.hidden = fullHidden;
+    els.removeBtn.hidden = fullHidden;
+    els.deselectBtn.disabled = !state.selectedPieceId;
+    els.inspectorCloseBtn.disabled = !state.selectedPieceId;
+
+    scheduleViewerResize();
   }
 
   function renderCatalog() {
-    updateCatalogCollapseUI();
+    renderLayoutState();
     els.catalogList.innerHTML = '';
     state.catalog.forEach(function (item, index) {
       if (item.spacing) {
@@ -378,6 +435,7 @@
       writeTransformInputs({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
       els.params.innerHTML = '<p>Select a piece to edit parameters.</p>';
       setPieceStatus('', 'info');
+      renderLayoutState();
       return;
     }
 
@@ -394,6 +452,7 @@
     } else {
       setPieceStatus('Ready', 'info');
     }
+    renderLayoutState();
   }
 
   function setTransformEnabled(enabled) {
@@ -555,6 +614,7 @@
   }
 
   function onClearPieces() {
+    if (!window.confirm('Clear the entire assembly? This will remove all parts.')) return;
     state.pieces = [];
     state.selectedPieceId = null;
     renderAssemblyList();

--- a/dist/assembler.js
+++ b/dist/assembler.js
@@ -1,0 +1,1200 @@
+(function () {
+  'use strict';
+
+  var FALLBACK_CATALOG = [
+    { file: 'examples/plate.jscad', title: 'Plate' },
+    { file: 'examples/L-plate.jscad', title: 'L-Plate' },
+    { file: 'examples/strip.jscad', title: 'Strip' },
+    { file: 'examples/triangular-plate.jscad', title: 'Triangular Plate' },
+    { file: 'examples/stl/Motor-Mount-28BYJ-48_M3INSERT.jscad', title: 'Motor Mount 28BYJ-48 M3 Insert' },
+    { file: 'examples/stl/wheel-hex_M3TAP.jscad', title: 'Wheel Hex M3 TAP' }
+  ];
+
+  var state = {
+    version: 1,
+    catalog: FALLBACK_CATALOG.slice(),
+    catalogCollapsed: false,
+    selectedCatalogIndex: 0,
+    selectedPieceId: null,
+    nextPieceCounter: 1,
+    viewer: null,
+    viewerResizeRaf: 0,
+    viewerResizeObserver: null,
+    engine: {
+      rebuildSolids: null,
+      rebuildSolidsInWorker: null,
+      getParameterDefinitions: null,
+      mergeSolids: null,
+      Viewer: null
+    },
+    sourceCache: {},
+    sourceCachePromises: {},
+    pieces: []
+  };
+
+  var els = {};
+  var renderQueued = false;
+
+  function whenReady() {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(bootstrap, 0);
+      });
+    } else {
+      setTimeout(bootstrap, 0);
+    }
+  }
+
+  async function bootstrap() {
+    cacheElements();
+    wireEvents();
+    renderCatalog();
+    renderAssemblyList();
+    renderInspector();
+    setGlobalStatus('Loading JSCAD core...', 'info');
+
+    try {
+      var response = await fetch('dist/min.js');
+      if (!response.ok) throw new Error('Failed to fetch dist/min.js (' + response.status + ')');
+      var source = await response.text();
+      var bundleRequire = (0, eval)(source);
+      if (typeof bundleRequire !== 'function') throw new Error('dist/min.js did not evaluate to a Browserify require function');
+
+      var _r1 = bundleRequire(1);
+      var getParameterDefinitions = bundleRequire(118);
+      var _r121 = bundleRequire(121);
+      var Viewer = bundleRequire(239);
+
+      state.engine.rebuildSolids = _r1.rebuildSolids;
+      state.engine.rebuildSolidsInWorker = _r1.rebuildSolidsInWorker;
+      state.engine.getParameterDefinitions = getParameterDefinitions;
+      state.engine.mergeSolids = _r121.mergeSolids;
+      state.engine.Viewer = Viewer;
+
+      initViewer();
+      installViewerResizeHandlers();
+      await loadCatalogFromIndex();
+      renderCatalog();
+      scheduleRender();
+      setGlobalStatus('Assembler ready.', 'info');
+    } catch (error) {
+      setGlobalStatus('Failed to initialize assembler: ' + errorMessage(error), 'error');
+    }
+  }
+
+  function cacheElements() {
+    els.catalogList = document.getElementById('asmCatalogList');
+    els.catalogToggle = document.getElementById('asmCatalogToggle');
+    els.catalogRoot = document.getElementById('asmCatalog');
+    els.pieceList = document.getElementById('asmPieceList');
+    els.inspectorHeader = document.getElementById('asmInspectorHeader');
+    els.partIdInput = document.getElementById('asmPartIdInput');
+    els.params = document.getElementById('asmParams');
+    els.pieceStatus = document.getElementById('asmPieceStatus');
+    els.viewerHost = document.getElementById('asmViewer');
+    els.viewerPanel = document.getElementById('asmViewerPanel');
+    els.importInput = document.getElementById('asmImportInput');
+    els.addBtn = document.getElementById('asmAddBtn');
+    els.dupBtn = document.getElementById('asmDuplicateBtn');
+    els.removeBtn = document.getElementById('asmRemoveBtn');
+    els.exportBtn = document.getElementById('asmExportBtn');
+    els.importBtn = document.getElementById('asmImportBtn');
+    els.clearBtn = document.getElementById('asmClearBtn');
+    els.posX = document.getElementById('asmPosX');
+    els.posY = document.getElementById('asmPosY');
+    els.posZ = document.getElementById('asmPosZ');
+    els.rotX = document.getElementById('asmRotX');
+    els.rotY = document.getElementById('asmRotY');
+    els.rotZ = document.getElementById('asmRotZ');
+  }
+
+  function wireEvents() {
+    els.addBtn.addEventListener('click', onAddPiece);
+    els.dupBtn.addEventListener('click', onDuplicatePiece);
+    els.removeBtn.addEventListener('click', onRemovePiece);
+    els.clearBtn.addEventListener('click', onClearPieces);
+    els.exportBtn.addEventListener('click', onExport);
+    els.importBtn.addEventListener('click', function () { els.importInput.click(); });
+    els.importInput.addEventListener('change', onImportChange);
+    els.catalogToggle.addEventListener('click', toggleCatalogList);
+    els.partIdInput.addEventListener('change', commitPartIdChange);
+    els.partIdInput.addEventListener('blur', commitPartIdChange);
+    els.partIdInput.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        commitPartIdChange();
+      }
+    });
+
+    [
+      { el: els.posX, axis: 'x', type: 'position' },
+      { el: els.posY, axis: 'y', type: 'position' },
+      { el: els.posZ, axis: 'z', type: 'position' },
+      { el: els.rotX, axis: 'x', type: 'rotation' },
+      { el: els.rotY, axis: 'y', type: 'rotation' },
+      { el: els.rotZ, axis: 'z', type: 'rotation' }
+    ].forEach(function (entry) {
+      entry.el.addEventListener('input', function () {
+        commitTransform(entry.type, entry.axis, entry.el.value);
+      });
+    });
+  }
+
+  function initViewer() {
+    if (!state.engine.Viewer || state.viewer) return;
+    state.viewer = new state.engine.Viewer(els.viewerHost, {
+      camera: {
+        fov: 45,
+        angle: { x: -50, y: 0, z: -35 },
+        position: { x: 0, y: 0, z: 120 },
+        clip: { min: 0.5, max: 1200 }
+      },
+      plate: { draw: true, size: 260 },
+      axis: { draw: true },
+      solid: { faces: true, lines: false }
+    });
+    state.viewer.clear();
+  }
+
+  function installViewerResizeHandlers() {
+    if (!state.viewer) return;
+    window.addEventListener('resize', scheduleViewerResize);
+
+    if (typeof ResizeObserver !== 'undefined') {
+      state.viewerResizeObserver = new ResizeObserver(function () {
+        scheduleViewerResize();
+      });
+      state.viewerResizeObserver.observe(els.viewerPanel);
+      state.viewerResizeObserver.observe(els.viewerHost);
+    }
+
+    scheduleViewerResize();
+  }
+
+  function scheduleViewerResize() {
+    if (!state.viewer) return;
+    if (state.viewerResizeRaf) cancelAnimationFrame(state.viewerResizeRaf);
+    state.viewerResizeRaf = requestAnimationFrame(function () {
+      state.viewerResizeRaf = 0;
+      if (!state.viewer) return;
+      try {
+        if (typeof state.viewer.handleResize === 'function') {
+          state.viewer.handleResize();
+        } else if (typeof state.viewer.onDraw === 'function') {
+          state.viewer.onDraw();
+        }
+      } catch (error) {}
+    });
+  }
+
+  async function loadCatalogFromIndex() {
+    try {
+      var response = await fetch('dist/index.js');
+      if (!response.ok) throw new Error('dist/index.js returned ' + response.status);
+      var source = await response.text();
+      var parsed = parseActiveExamplesFromIndex(source);
+      if (!parsed.length) throw new Error('No examples found in active block.');
+      state.catalog = parsed;
+      state.selectedCatalogIndex = clamp(state.selectedCatalogIndex, 0, state.catalog.length - 1);
+    } catch (error) {
+      state.catalog = FALLBACK_CATALOG.slice();
+      state.selectedCatalogIndex = clamp(state.selectedCatalogIndex, 0, state.catalog.length - 1);
+      setGlobalStatus('Catalog fallback in use: ' + errorMessage(error), 'error');
+    }
+  }
+
+  function parseActiveExamplesFromIndex(source) {
+    var fnMarker = 'function createExamples(me)';
+    var fnIndex = source.indexOf(fnMarker);
+    if (fnIndex < 0) throw new Error('createExamples(me) block not found.');
+
+    var marker = 'var examples = [';
+    var startIndex = source.lastIndexOf(marker, fnIndex);
+    if (startIndex < 0) throw new Error('active var examples block not found.');
+
+    var arrayStart = source.indexOf('[', startIndex);
+    if (arrayStart < 0) throw new Error('examples array start not found.');
+    var arrayEnd = findArrayEnd(source, arrayStart);
+    var literal = source.slice(arrayStart, arrayEnd + 1);
+
+    var raw = (new Function('return (' + literal + ');'))();
+    if (!Array.isArray(raw)) throw new Error('examples block is not an array.');
+
+    return raw.map(function (entry) {
+      if (!entry || typeof entry !== 'object' || typeof entry.file !== 'string') return null;
+      var file = entry.file.indexOf('examples/') === 0 ? entry.file : 'examples/' + entry.file;
+      return {
+        file: file,
+        title: entry.title || entry.file,
+        spacing: !!entry.spacing,
+        new: !!entry.new,
+        type: entry.type || '',
+        wrap: !!entry.wrap
+      };
+    }).filter(Boolean);
+  }
+
+  function findArrayEnd(source, openBracketIndex) {
+    var depth = 0;
+    var inSingle = false;
+    var inDouble = false;
+    var inTemplate = false;
+    var inLineComment = false;
+    var inBlockComment = false;
+
+    for (var i = openBracketIndex; i < source.length; i++) {
+      var ch = source[i];
+      var next = source[i + 1];
+
+      if (inLineComment) {
+        if (ch === '\n') inLineComment = false;
+        continue;
+      }
+      if (inBlockComment) {
+        if (ch === '*' && next === '/') {
+          inBlockComment = false;
+          i += 1;
+        }
+        continue;
+      }
+      if (inSingle) {
+        if (ch === '\\') i += 1;
+        else if (ch === '\'') inSingle = false;
+        continue;
+      }
+      if (inDouble) {
+        if (ch === '\\') i += 1;
+        else if (ch === '"') inDouble = false;
+        continue;
+      }
+      if (inTemplate) {
+        if (ch === '\\') i += 1;
+        else if (ch === '`') inTemplate = false;
+        continue;
+      }
+
+      if (ch === '/' && next === '/') {
+        inLineComment = true;
+        i += 1;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        inBlockComment = true;
+        i += 1;
+        continue;
+      }
+      if (ch === '\'') { inSingle = true; continue; }
+      if (ch === '"') { inDouble = true; continue; }
+      if (ch === '`') { inTemplate = true; continue; }
+
+      if (ch === '[') depth += 1;
+      if (ch === ']') {
+        depth -= 1;
+        if (depth === 0) return i;
+      }
+    }
+
+    throw new Error('examples array end not found.');
+  }
+
+  function toggleCatalogList() {
+    state.catalogCollapsed = !state.catalogCollapsed;
+    updateCatalogCollapseUI();
+  }
+
+  function updateCatalogCollapseUI() {
+    if (!els.catalogRoot || !els.catalogToggle) return;
+    els.catalogRoot.classList.toggle('is-collapsed', !!state.catalogCollapsed);
+    els.catalogToggle.setAttribute('aria-expanded', state.catalogCollapsed ? 'false' : 'true');
+    els.catalogToggle.textContent = state.catalogCollapsed ? 'Expand' : 'Collapse';
+  }
+
+  function renderCatalog() {
+    updateCatalogCollapseUI();
+    els.catalogList.innerHTML = '';
+    state.catalog.forEach(function (item, index) {
+      if (item.spacing) {
+        var divider = document.createElement('li');
+        divider.className = 'asm-divider';
+        divider.setAttribute('aria-hidden', 'true');
+        els.catalogList.appendChild(divider);
+      }
+
+      var li = document.createElement('li');
+      if (index === state.selectedCatalogIndex) li.classList.add('is-selected');
+      li.addEventListener('click', function () {
+        state.selectedCatalogIndex = index;
+        renderCatalog();
+      });
+
+      var title = document.createElement('span');
+      title.className = 'asm-catalog-item-title';
+      title.textContent = item.title;
+      li.appendChild(title);
+
+      if (item.new) {
+        var newBadge = document.createElement('span');
+        newBadge.className = 'asm-new-badge';
+        newBadge.textContent = 'NEW';
+        li.appendChild(newBadge);
+      }
+
+      if (item.type) {
+        var typeBadge = document.createElement('span');
+        typeBadge.className = 'asm-type-badge';
+        typeBadge.textContent = item.type;
+        li.appendChild(typeBadge);
+      }
+
+      els.catalogList.appendChild(li);
+    });
+  }
+
+  function renderAssemblyList() {
+    els.pieceList.innerHTML = '';
+    state.pieces.forEach(function (piece) {
+      var li = document.createElement('li');
+      li.textContent = piece.title + ' (' + piece.id + ')';
+      if (piece.id === state.selectedPieceId) li.classList.add('is-selected');
+      if (piece.loading) li.classList.add('is-loading');
+      if (piece.error) li.classList.add('is-error');
+      li.addEventListener('click', function () {
+        state.selectedPieceId = piece.id;
+        renderAssemblyList();
+        renderInspector();
+        scheduleRender();
+      });
+      els.pieceList.appendChild(li);
+    });
+  }
+
+  function renderInspector() {
+    var piece = getSelectedPiece();
+    if (!piece) {
+      els.inspectorHeader.textContent = 'No selection';
+      els.partIdInput.value = '';
+      els.partIdInput.disabled = true;
+      setTransformEnabled(false);
+      writeTransformInputs({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
+      els.params.innerHTML = '<p>Select a piece to edit parameters.</p>';
+      setPieceStatus('', 'info');
+      return;
+    }
+
+    els.inspectorHeader.textContent = piece.title;
+    els.partIdInput.disabled = false;
+    els.partIdInput.value = piece.id;
+    setTransformEnabled(true);
+    writeTransformInputs(piece.position, piece.rotation);
+    buildParameterUI(piece);
+    if (piece.error) {
+      setPieceStatus(errorMessage(piece.error), 'error');
+    } else if (piece.loading) {
+      setPieceStatus('Building...', 'info');
+    } else {
+      setPieceStatus('Ready', 'info');
+    }
+  }
+
+  function setTransformEnabled(enabled) {
+    [els.posX, els.posY, els.posZ, els.rotX, els.rotY, els.rotZ].forEach(function (el) {
+      el.disabled = !enabled;
+    });
+  }
+
+  function writeTransformInputs(position, rotation) {
+    els.posX.value = safeNumber(position.x);
+    els.posY.value = safeNumber(position.y);
+    els.posZ.value = safeNumber(position.z);
+    els.rotX.value = safeNumber(rotation.x);
+    els.rotY.value = safeNumber(rotation.y);
+    els.rotZ.value = safeNumber(rotation.z);
+  }
+
+  function safeNumber(value) {
+    return Number.isFinite(Number(value)) ? String(Number(value)) : '0';
+  }
+
+  function getSelectedPiece() {
+    for (var i = 0; i < state.pieces.length; i++) {
+      if (state.pieces[i].id === state.selectedPieceId) return state.pieces[i];
+    }
+    return null;
+  }
+
+  function makePieceFromCatalog(item) {
+    return {
+      id: createPieceId(),
+      file: item.file,
+      title: item.title,
+      paramsDiff: {},
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      builtObjects: null,
+      lastGoodObjects: null,
+      buildKey: '',
+      buildToken: 0,
+      loading: false,
+      error: null,
+      _pendingImportParams: null
+    };
+  }
+
+  function createPieceId() {
+    var id;
+    do {
+      id = sanitizePieceId('piece_' + String(state.nextPieceCounter).padStart(3, '0'), 'piece');
+      state.nextPieceCounter += 1;
+      id = makeUniquePieceId(id);
+    } while (!id);
+    return id;
+  }
+
+  function commitPartIdChange() {
+    var piece = getSelectedPiece();
+    if (!piece) return;
+    var nextId = makeUniquePieceId(sanitizePieceId(els.partIdInput.value, piece.id), piece);
+    if (!nextId) nextId = piece.id;
+    if (nextId === piece.id) {
+      els.partIdInput.value = piece.id;
+      return;
+    }
+    piece.id = nextId;
+    state.selectedPieceId = nextId;
+    els.partIdInput.value = nextId;
+    renderAssemblyList();
+    renderInspector();
+    scheduleRender();
+  }
+
+  function sanitizePieceId(raw, fallback) {
+    var text = String(raw == null ? '' : raw).trim();
+    text = text.replace(/[^A-Za-z0-9_-]+/g, '_');
+    text = text.replace(/^_+|_+$/g, '');
+    if (!text) {
+      text = String(fallback || 'piece').replace(/[^A-Za-z0-9_-]+/g, '_');
+      text = text.replace(/^_+|_+$/g, '') || 'piece';
+    }
+    return text;
+  }
+
+  function makeUniquePieceId(baseId, exceptPiece) {
+    var seed = sanitizePieceId(baseId, 'piece');
+    var used = {};
+    state.pieces.forEach(function (p) {
+      if (!p || p === exceptPiece) return;
+      used[p.id] = true;
+    });
+    if (!used[seed]) return seed;
+    var counter = 2;
+    var candidate = seed + '_' + counter;
+    while (used[candidate]) {
+      counter += 1;
+      candidate = seed + '_' + counter;
+    }
+    return candidate;
+  }
+
+  function onAddPiece() {
+    var item = state.catalog[state.selectedCatalogIndex] || state.catalog[0];
+    if (!item) return;
+    var piece = makePieceFromCatalog(item);
+    state.pieces.push(piece);
+    state.selectedPieceId = piece.id;
+    renderAssemblyList();
+    renderInspector();
+    rebuildPiece(piece);
+  }
+
+  function onDuplicatePiece() {
+    var piece = getSelectedPiece();
+    if (!piece) return;
+    var copy = {
+      id: createPieceId(),
+      file: piece.file,
+      title: piece.title,
+      paramsDiff: cloneValue(piece.paramsDiff),
+      position: cloneValue(piece.position),
+      rotation: cloneValue(piece.rotation),
+      builtObjects: null,
+      lastGoodObjects: null,
+      buildKey: '',
+      buildToken: 0,
+      loading: false,
+      error: null,
+      _pendingImportParams: null
+    };
+    state.pieces.push(copy);
+    state.selectedPieceId = copy.id;
+    renderAssemblyList();
+    renderInspector();
+    rebuildPiece(copy);
+  }
+
+  function onRemovePiece() {
+    var index = -1;
+    for (var i = 0; i < state.pieces.length; i++) {
+      if (state.pieces[i].id === state.selectedPieceId) {
+        index = i;
+        break;
+      }
+    }
+    if (index < 0) return;
+
+    state.pieces.splice(index, 1);
+    if (state.pieces.length) {
+      var nextIndex = Math.min(index, state.pieces.length - 1);
+      state.selectedPieceId = state.pieces[nextIndex].id;
+    } else {
+      state.selectedPieceId = null;
+    }
+
+    renderAssemblyList();
+    renderInspector();
+    scheduleRender();
+  }
+
+  function onClearPieces() {
+    state.pieces = [];
+    state.selectedPieceId = null;
+    renderAssemblyList();
+    renderInspector();
+    if (state.viewer) state.viewer.clear();
+  }
+
+  function commitTransform(kind, axis, rawValue) {
+    var piece = getSelectedPiece();
+    if (!piece) return;
+    if (!isCommittedNumber(rawValue)) return;
+    var value = Number(rawValue);
+    piece[kind][axis] = value;
+    if (piece.error && piece.error.indexOf('Transform failed:') === 0) {
+      piece.error = null;
+      renderAssemblyList();
+      renderInspector();
+    }
+    scheduleRender();
+  }
+
+  function isCommittedNumber(text) {
+    if (typeof text !== 'string') return false;
+    var trimmed = text.trim();
+    if (!trimmed) return false;
+    if (/^[+-]?$/.test(trimmed)) return false;
+    if (/^[+-]?\d+\.$/.test(trimmed)) return false;
+    var n = Number(trimmed);
+    return Number.isFinite(n);
+  }
+
+  async function ensureSource(piece) {
+    if (state.sourceCache[piece.file]) return state.sourceCache[piece.file];
+    if (state.sourceCachePromises[piece.file]) return state.sourceCachePromises[piece.file];
+
+    state.sourceCachePromises[piece.file] = (async function () {
+      var fullUrl = new URL(piece.file, location.href).href;
+      var response = await fetch(piece.file);
+      if (!response.ok) throw new Error('Failed to load ' + piece.file + ' (' + response.status + ')');
+      var source = await response.text();
+
+      var paramDefinitions = [];
+      var defaultParams = {};
+      try {
+        paramDefinitions = state.engine.getParameterDefinitions ? (state.engine.getParameterDefinitions(source) || []) : [];
+        defaultParams = getDefaultParams(paramDefinitions);
+      } catch (error) {
+        paramDefinitions = [];
+        defaultParams = {};
+      }
+
+      var cache = {
+        source: source,
+        fullUrl: fullUrl,
+        paramDefinitions: paramDefinitions,
+        defaultParams: defaultParams
+      };
+      state.sourceCache[piece.file] = cache;
+      return cache;
+    })();
+
+    try {
+      return await state.sourceCachePromises[piece.file];
+    } finally {
+      delete state.sourceCachePromises[piece.file];
+    }
+  }
+
+  function getDefaultParams(definitions) {
+    var out = {};
+    (definitions || []).forEach(function (definition) {
+      if (!definition || !definition.name) return;
+      var type = String(definition.type || 'text').toLowerCase();
+      if (type === 'group') return;
+
+      if (type === 'checkbox') {
+        out[definition.name] = !!definition.checked;
+        return;
+      }
+
+      if (type === 'radio') {
+        if ('checked' in definition) {
+          out[definition.name] = definition.checked;
+          return;
+        }
+        if ('initial' in definition) {
+          out[definition.name] = definition.initial;
+          return;
+        }
+        if ('default' in definition) {
+          out[definition.name] = definition.default;
+          return;
+        }
+        var rv = getChoiceValues(definition);
+        out[definition.name] = rv.length ? rv[0] : '';
+        return;
+      }
+
+      if (type === 'choice') {
+        if ('default' in definition) {
+          out[definition.name] = definition.default;
+          return;
+        }
+        if ('initial' in definition) {
+          out[definition.name] = definition.initial;
+          return;
+        }
+        var values = getChoiceValues(definition);
+        out[definition.name] = values.length ? values[0] : '';
+        return;
+      }
+
+      if (type === 'int' || type === 'float' || type === 'number' || type === 'slider') {
+        var numericBase = 'initial' in definition ? definition.initial : definition.default;
+        var n = Number(numericBase);
+        out[definition.name] = Number.isFinite(n) ? n : 0;
+        return;
+      }
+
+      if (type === 'color') {
+        out[definition.name] = 'initial' in definition ? String(definition.initial) : ('default' in definition ? String(definition.default) : '#808080');
+        return;
+      }
+
+      out[definition.name] = 'initial' in definition ? definition.initial : ('default' in definition ? definition.default : '');
+    });
+    return out;
+  }
+
+  function getChoiceValues(definition) {
+    if (Array.isArray(definition.values)) return definition.values;
+    if (Array.isArray(definition.captions) && definition.captions.length) return definition.captions;
+    return [];
+  }
+
+  function getEffectiveParams(piece, defaults) {
+    return Object.assign({}, defaults || {}, piece.paramsDiff || {});
+  }
+
+  function normalizeParamsDiff(defaults, incoming) {
+    var normalized = {};
+    var src = incoming || {};
+    Object.keys(src).forEach(function (key) {
+      if (!(key in defaults)) return;
+      var value = src[key];
+      var defValue = defaults[key];
+      if (!isEqualValue(value, defValue)) normalized[key] = value;
+    });
+    return normalized;
+  }
+
+  function isEqualValue(a, b) {
+    if (typeof a === 'number' || typeof b === 'number') {
+      return Number(a) === Number(b);
+    }
+    return String(a) === String(b);
+  }
+
+  function stableStringify(value) {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value);
+    if (Array.isArray(value)) return '[' + value.map(stableStringify).join(',') + ']';
+
+    var keys = Object.keys(value).sort();
+    var fields = keys.map(function (k) {
+      return JSON.stringify(k) + ':' + stableStringify(value[k]);
+    });
+    return '{' + fields.join(',') + '}';
+  }
+
+  function buildWithWorkerOrMain(piece, cache, effectiveParams, token) {
+    return new Promise(function (resolve, reject) {
+      var settled = false;
+      var workerJob = null;
+
+      function done(err, objects) {
+        if (settled) return;
+        settled = true;
+        if (piece.buildToken !== token) return resolve({ stale: true });
+        if (err) return reject(err);
+        resolve({ objects: objects });
+      }
+
+      function runMainThread() {
+        if (!state.engine.rebuildSolids) {
+          reject(new Error('No rebuild engine available.'));
+          return;
+        }
+        try {
+          state.engine.rebuildSolids(cache.source, cache.fullUrl, effectiveParams, done, {});
+        } catch (error) {
+          reject(error);
+        }
+      }
+
+      if (typeof state.engine.rebuildSolidsInWorker === 'function') {
+        try {
+          workerJob = state.engine.rebuildSolidsInWorker(cache.source, cache.fullUrl, effectiveParams, done, {});
+        } catch (error) {
+          workerJob = null;
+        }
+      }
+
+      if (!workerJob) {
+        runMainThread();
+        return;
+      }
+
+      setTimeout(function () {
+        if (settled) return;
+        try {
+          if (workerJob && typeof workerJob.cancel === 'function') workerJob.cancel();
+        } catch (cancelErr) {}
+        runMainThread();
+      }, 3500);
+    });
+  }
+
+  async function rebuildPiece(piece) {
+    if (!state.engine.rebuildSolids && !state.engine.rebuildSolidsInWorker) return;
+
+    piece.loading = true;
+    piece.error = null;
+    renderAssemblyList();
+    if (piece.id === state.selectedPieceId) renderInspector();
+
+    try {
+      var cache = await ensureSource(piece);
+      if (piece._pendingImportParams) {
+        piece.paramsDiff = normalizeParamsDiff(cache.defaultParams, piece._pendingImportParams);
+        piece._pendingImportParams = null;
+      } else {
+        piece.paramsDiff = normalizeParamsDiff(cache.defaultParams, piece.paramsDiff);
+      }
+
+      var effectiveParams = getEffectiveParams(piece, cache.defaultParams);
+      var buildKey = stableStringify({ file: piece.file, effectiveParams: effectiveParams });
+      if (piece.buildKey === buildKey && piece.builtObjects) {
+        piece.loading = false;
+        piece.error = null;
+        renderAssemblyList();
+        if (piece.id === state.selectedPieceId) renderInspector();
+        scheduleRender();
+        return;
+      }
+
+      piece.buildKey = buildKey;
+      piece.buildToken += 1;
+      var token = piece.buildToken;
+      var result = await buildWithWorkerOrMain(piece, cache, effectiveParams, token);
+      if (result && result.stale) return;
+
+      piece.builtObjects = Array.isArray(result.objects) ? result.objects : [];
+      piece.lastGoodObjects = piece.builtObjects;
+      piece.error = null;
+    } catch (error) {
+      piece.error = errorMessage(error);
+    } finally {
+      piece.loading = false;
+      renderAssemblyList();
+      if (piece.id === state.selectedPieceId) renderInspector();
+      scheduleRender();
+    }
+  }
+
+  function scheduleRender() {
+    if (renderQueued) return;
+    renderQueued = true;
+    requestAnimationFrame(function () {
+      renderQueued = false;
+      renderAssembly();
+    });
+  }
+
+  function renderAssembly() {
+    if (!state.viewer || !state.engine.mergeSolids) return;
+
+    var all = [];
+    state.pieces.forEach(function (piece) {
+      var sourceObjects = piece.builtObjects || piece.lastGoodObjects;
+      if (!sourceObjects || !sourceObjects.length) return;
+
+      var hadTransformError = false;
+      sourceObjects.forEach(function (obj) {
+        try {
+          var transformed = applyPieceTransform(obj, piece);
+          if (piece.id === state.selectedPieceId) {
+            transformed = colorizeSelected(transformed);
+          }
+          all.push(transformed);
+        } catch (error) {
+          hadTransformError = true;
+          piece.error = 'Transform failed: ' + errorMessage(error);
+        }
+      });
+
+      if (!hadTransformError && piece.error && piece.error.indexOf('Transform failed:') === 0) {
+        piece.error = null;
+      }
+    });
+
+    renderAssemblyList();
+    if (getSelectedPiece()) renderInspector();
+
+    if (!all.length) {
+      state.viewer.clear();
+      return;
+    }
+
+    try {
+      var merged = state.engine.mergeSolids(all);
+      state.viewer.setCsg(merged);
+    } catch (error) {
+      setGlobalStatus('Render failed: ' + errorMessage(error), 'error');
+    }
+  }
+
+  function colorizeSelected(obj) {
+    try {
+      if (obj && typeof obj.setColor === 'function') {
+        return obj.setColor([1.0, 0.72, 0.2, 1.0]);
+      }
+    } catch (error) {}
+    return obj;
+  }
+
+  function applyPieceTransform(obj, piece) {
+    var out = obj;
+    out = out.rotateX(Number(piece.rotation.x) || 0);
+    out = out.rotateY(Number(piece.rotation.y) || 0);
+    out = out.rotateZ(Number(piece.rotation.z) || 0);
+    out = out.translate([
+      Number(piece.position.x) || 0,
+      Number(piece.position.y) || 0,
+      Number(piece.position.z) || 0
+    ]);
+    return out;
+  }
+
+  function buildParameterUI(piece) {
+    var cache = state.sourceCache[piece.file];
+    if (!cache || !cache.paramDefinitions) {
+      els.params.innerHTML = '<p>Parameters unavailable until source loads.</p>';
+      return;
+    }
+
+    var defaults = cache.defaultParams;
+    var effective = getEffectiveParams(piece, defaults);
+    els.params.innerHTML = '';
+
+    cache.paramDefinitions.forEach(function (definition, idx) {
+      if (!definition) return;
+      var type = String(definition.type || 'text').toLowerCase();
+      if (type === 'group') {
+        var group = document.createElement('div');
+        group.className = 'asm-group';
+        var title = document.createElement('div');
+        title.className = 'asm-group-title';
+        renderCaption(title, definition.caption, definition.name || 'Group');
+        group.appendChild(title);
+        els.params.appendChild(group);
+        return;
+      }
+      if (!definition.name) return;
+      els.params.appendChild(createParamControl(piece, definition, effective[definition.name], defaults[definition.name], idx));
+    });
+  }
+
+  function renderCaption(node, caption, fallbackText) {
+    if (caption != null && caption !== '') {
+      node.innerHTML = String(caption);
+      return;
+    }
+    node.textContent = fallbackText || '';
+  }
+
+  function createParamControl(piece, definition, value, defaultValue, index) {
+    var wrap = document.createElement('div');
+    wrap.className = 'asm-param';
+    var label = document.createElement('label');
+    renderCaption(label, definition.caption, definition.name);
+    wrap.appendChild(label);
+
+    var type = String(definition.type || 'text').toLowerCase();
+    var input;
+
+    if (type === 'choice') {
+      input = document.createElement('select');
+      var vals = getChoiceValues(definition);
+      var captions = Array.isArray(definition.captions) ? definition.captions : vals;
+      vals.forEach(function (v, i) {
+        var opt = document.createElement('option');
+        opt.value = String(v);
+        opt.textContent = captions[i] != null ? String(captions[i]) : String(v);
+        if (String(value) === String(v)) opt.selected = true;
+        input.appendChild(opt);
+      });
+      input.addEventListener('change', function () {
+        updateParam(piece, definition, input.value, defaultValue);
+      });
+    } else if (type === 'radio') {
+      input = document.createElement('div');
+      var radioVals = getChoiceValues(definition);
+      var radioCaps = Array.isArray(definition.captions) ? definition.captions : radioVals;
+      radioVals.forEach(function (v, i) {
+        var row = document.createElement('label');
+        var r = document.createElement('input');
+        r.type = 'radio';
+        r.name = 'asm_radio_' + piece.id + '_' + index;
+        r.value = String(v);
+        r.checked = String(value) === String(v);
+        r.addEventListener('change', function () {
+          if (r.checked) updateParam(piece, definition, r.value, defaultValue);
+        });
+        row.appendChild(r);
+        row.appendChild(document.createTextNode(' ' + (radioCaps[i] != null ? radioCaps[i] : v)));
+        input.appendChild(row);
+      });
+    } else {
+      input = document.createElement('input');
+      if (type === 'checkbox') {
+        input.type = 'checkbox';
+        input.checked = !!value;
+        input.addEventListener('change', function () {
+          updateParam(piece, definition, input.checked, defaultValue);
+        });
+      } else if (type === 'color') {
+        input.type = 'color';
+        input.value = normalizeColor(value);
+        input.addEventListener('input', function () {
+          updateParam(piece, definition, input.value, defaultValue);
+        });
+      } else if (type === 'slider') {
+        input.type = 'range';
+        if ('min' in definition) input.min = String(definition.min);
+        if ('max' in definition) input.max = String(definition.max);
+        input.step = 'step' in definition ? String(definition.step) : 'any';
+        input.value = String(value);
+        input.addEventListener('input', function () {
+          updateParam(piece, definition, Number(input.value), defaultValue);
+        });
+      } else if (type === 'int' || type === 'float' || type === 'number') {
+        input.type = 'number';
+        input.step = type === 'int' ? '1' : 'any';
+        if ('min' in definition) input.min = String(definition.min);
+        if ('max' in definition) input.max = String(definition.max);
+        input.value = String(value);
+        input.addEventListener('input', function () {
+          if (!isCommittedNumber(input.value)) return;
+          var n = Number(input.value);
+          if (!Number.isFinite(n)) return;
+          if (type === 'int') n = Math.trunc(n);
+          updateParam(piece, definition, n, defaultValue);
+        });
+      } else {
+        input.type = 'text';
+        input.value = value == null ? '' : String(value);
+        input.addEventListener('input', function () {
+          updateParam(piece, definition, input.value, defaultValue);
+        });
+      }
+    }
+
+    wrap.appendChild(input);
+    return wrap;
+  }
+
+  function normalizeColor(value) {
+    var text = String(value || '').trim();
+    if (/^#[0-9a-fA-F]{6}$/.test(text)) return text;
+    if (/^#[0-9a-fA-F]{3}$/.test(text)) {
+      return '#' + text[1] + text[1] + text[2] + text[2] + text[3] + text[3];
+    }
+    return '#808080';
+  }
+
+  function updateParam(piece, definition, value, defaultValue) {
+    var key = definition.name;
+    if (!key) return;
+
+    if (isEqualValue(value, defaultValue)) {
+      delete piece.paramsDiff[key];
+    } else {
+      piece.paramsDiff[key] = value;
+    }
+
+    rebuildPiece(piece);
+  }
+
+  function onExport() {
+    var payload = {
+      version: 1,
+      pieces: state.pieces.map(function (piece) {
+        return {
+          id: piece.id,
+          file: piece.file,
+          params: cloneValue(piece.paramsDiff || {}),
+          position: {
+            x: Number(piece.position.x) || 0,
+            y: Number(piece.position.y) || 0,
+            z: Number(piece.position.z) || 0
+          },
+          rotation: {
+            x: Number(piece.rotation.x) || 0,
+            y: Number(piece.rotation.y) || 0,
+            z: Number(piece.rotation.z) || 0
+          }
+        };
+      })
+    };
+
+    var blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'assembly.json';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    setGlobalStatus('Exported assembly.json', 'info');
+  }
+
+  function onImportChange(event) {
+    var file = event.target.files && event.target.files[0];
+    if (!file) return;
+
+    var reader = new FileReader();
+    reader.onload = function () {
+      try {
+        var parsed = JSON.parse(String(reader.result || ''));
+        importAssembly(parsed);
+        setGlobalStatus('Imported assembly JSON.', 'info');
+      } catch (error) {
+        setGlobalStatus('Import failed: ' + errorMessage(error), 'error');
+      } finally {
+        els.importInput.value = '';
+      }
+    };
+    reader.onerror = function () {
+      setGlobalStatus('Import failed: unable to read file.', 'error');
+      els.importInput.value = '';
+    };
+    reader.readAsText(file);
+  }
+
+  function importAssembly(payload) {
+    if (!payload || typeof payload !== 'object') throw new Error('Top-level JSON must be an object.');
+    if (!Array.isArray(payload.pieces)) throw new Error('JSON must include a pieces array.');
+
+    var usedIds = {};
+    var newPieces = payload.pieces.map(function (raw) {
+      if (!raw || typeof raw !== 'object') throw new Error('Each piece must be an object.');
+      if (!raw.file || typeof raw.file !== 'string') throw new Error('Each piece must include a file path.');
+
+      var baseId = sanitizePieceId(raw.id, 'piece');
+      var uniqueId = baseId;
+      var suffix = 2;
+      while (usedIds[uniqueId]) {
+        uniqueId = baseId + '_' + suffix;
+        suffix += 1;
+      }
+      usedIds[uniqueId] = true;
+
+      return {
+        id: uniqueId,
+        file: raw.file,
+        title: inferTitle(raw.file),
+        paramsDiff: {},
+        position: normalizeVector(raw.position),
+        rotation: normalizeVector(raw.rotation),
+        builtObjects: null,
+        lastGoodObjects: null,
+        buildKey: '',
+        buildToken: 0,
+        loading: false,
+        error: null,
+        _pendingImportParams: raw.params && typeof raw.params === 'object' ? cloneValue(raw.params) : {}
+      };
+    });
+
+    state.pieces = newPieces;
+    state.selectedPieceId = newPieces.length ? newPieces[0].id : null;
+    renderAssemblyList();
+    renderInspector();
+
+    newPieces.forEach(function (piece) {
+      rebuildPiece(piece);
+    });
+
+    if (!newPieces.length && state.viewer) {
+      state.viewer.clear();
+    }
+  }
+
+  function inferTitle(file) {
+    for (var i = 0; i < state.catalog.length; i++) {
+      if (state.catalog[i].file === file) return state.catalog[i].title;
+    }
+    var parts = String(file).split('/');
+    return parts[parts.length - 1] || file;
+  }
+
+  function normalizeVector(raw) {
+    raw = raw || {};
+    return {
+      x: Number.isFinite(Number(raw.x)) ? Number(raw.x) : 0,
+      y: Number.isFinite(Number(raw.y)) ? Number(raw.y) : 0,
+      z: Number.isFinite(Number(raw.z)) ? Number(raw.z) : 0
+    };
+  }
+
+  function cloneValue(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function clamp(value, min, max) {
+    if (!Number.isFinite(value)) return min;
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+
+  function setGlobalStatus(message, kind) {
+    if (kind === 'error') {
+      console.error('[assembler]', message || '');
+      return;
+    }
+    console.log('[assembler]', message || '');
+  }
+
+  function setPieceStatus(message, kind) {
+    els.pieceStatus.textContent = message || '';
+    els.pieceStatus.className = kind === 'error' ? 'is-error' : 'is-info';
+  }
+
+  function errorMessage(error) {
+    if (!error) return 'Unknown error';
+    if (typeof error === 'string') return error;
+    return error.message || String(error);
+  }
+
+  whenReady();
+})();

--- a/dist/assembler.js
+++ b/dist/assembler.js
@@ -13,7 +13,7 @@
   var state = {
     version: 1,
     catalog: FALLBACK_CATALOG.slice(),
-    catalogHidden: false,
+    catalogCollapsed: false,
     panelsHidden: false,
     selectedCatalogIndex: 0,
     selectedPieceId: null,
@@ -105,7 +105,6 @@
     els.importBtn = document.getElementById('asmImportBtn');
     els.clearBtn = document.getElementById('asmClearBtn');
     els.hidePanelsBtn = document.getElementById('asmHidePanelsBtn');
-    els.showLeftPanelBtn = document.getElementById('asmShowLeftPanelBtn');
     els.posX = document.getElementById('asmPosX');
     els.posY = document.getElementById('asmPosY');
     els.posZ = document.getElementById('asmPosZ');
@@ -126,7 +125,6 @@
     els.deselectBtn.addEventListener('click', deselectSelectedPiece);
     els.inspectorCloseBtn.addEventListener('click', deselectSelectedPiece);
     els.hidePanelsBtn.addEventListener('click', hidePanels);
-    els.showLeftPanelBtn.addEventListener('click', showLeftPanel);
     els.partIdInput.addEventListener('change', commitPartIdChange);
     els.partIdInput.addEventListener('blur', commitPartIdChange);
     els.partIdInput.addEventListener('keydown', function (event) {
@@ -308,28 +306,12 @@
   }
 
   function toggleCatalogList() {
-    if (state.panelsHidden) {
-      state.panelsHidden = false;
-      state.catalogHidden = false;
-    } else {
-      state.catalogHidden = !state.catalogHidden;
-    }
+    state.catalogCollapsed = !state.catalogCollapsed;
     renderLayoutState();
-    scheduleViewerResize();
   }
 
   function hidePanels() {
-    state.panelsHidden = true;
-    state.catalogHidden = true;
-    state.selectedPieceId = null;
-    renderAssemblyList();
-    renderInspector();
-    scheduleRender();
-  }
-
-  function showLeftPanel() {
-    state.panelsHidden = false;
-    state.catalogHidden = false;
+    state.panelsHidden = !state.panelsHidden;
     state.selectedPieceId = null;
     renderAssemblyList();
     renderInspector();
@@ -346,20 +328,20 @@
 
   function renderLayoutState() {
     var inspectorVisible = !state.panelsHidden && !!state.selectedPieceId;
-    var catalogVisible = !state.panelsHidden && !state.catalogHidden;
+    var catalogVisible = !state.panelsHidden;
 
-    els.layout.classList.toggle('is-catalog-hidden', !catalogVisible);
+    els.layout.classList.toggle('is-panels-hidden', !catalogVisible);
     els.layout.classList.toggle('is-inspector-hidden', !inspectorVisible);
-    els.layout.classList.toggle('is-viewer-only', !catalogVisible && !inspectorVisible);
+    els.catalogRoot.classList.toggle('is-catalog-collapsed', !!state.catalogCollapsed);
 
-    els.catalogToggle.textContent = catalogVisible ? 'Close Catalog' : 'Open Catalog';
-    els.catalogToggle.setAttribute('aria-expanded', catalogVisible ? 'true' : 'false');
+    els.catalogToggle.textContent = state.catalogCollapsed ? 'Expand' : 'Collapse';
+    els.catalogToggle.setAttribute('aria-expanded', state.catalogCollapsed ? 'false' : 'true');
 
     var fullHidden = !!state.panelsHidden;
-    els.showLeftPanelBtn.hidden = !fullHidden;
     els.addBtn.hidden = fullHidden;
     els.dupBtn.hidden = fullHidden;
     els.removeBtn.hidden = fullHidden;
+    els.hidePanelsBtn.textContent = fullHidden ? 'Show Panel' : 'Hide Panel';
     els.deselectBtn.disabled = !state.selectedPieceId;
     els.inspectorCloseBtn.disabled = !state.selectedPieceId;
 
@@ -993,9 +975,6 @@
   function createParamControl(piece, definition, value, defaultValue, index) {
     var wrap = document.createElement('div');
     wrap.className = 'asm-param';
-    var label = document.createElement('label');
-    renderCaption(label, definition.caption, definition.name);
-    wrap.appendChild(label);
 
     var type = String(definition.type || 'text').toLowerCase();
     var input;
@@ -1035,11 +1014,20 @@
     } else {
       input = document.createElement('input');
       if (type === 'checkbox') {
+        wrap.classList.add('asm-param-checkbox');
         input.type = 'checkbox';
         input.checked = !!value;
+        input.id = 'asm_param_' + piece.id + '_' + index;
         input.addEventListener('change', function () {
           updateParam(piece, definition, input.checked, defaultValue);
         });
+        wrap.appendChild(input);
+
+        var checkboxLabel = document.createElement('label');
+        checkboxLabel.setAttribute('for', input.id);
+        renderCaption(checkboxLabel, definition.caption, definition.name);
+        wrap.appendChild(checkboxLabel);
+        return wrap;
       } else if (type === 'color') {
         input.type = 'color';
         input.value = normalizeColor(value);
@@ -1077,6 +1065,9 @@
       }
     }
 
+    var label = document.createElement('label');
+    renderCaption(label, definition.caption, definition.name);
+    wrap.appendChild(label);
     wrap.appendChild(input);
     return wrap;
   }

--- a/dist/assembler.js
+++ b/dist/assembler.js
@@ -93,6 +93,7 @@
     els.inspectorHeader = document.getElementById('asmInspectorHeader');
     els.inspectorCloseBtn = document.getElementById('asmInspectorCloseBtn');
     els.partIdInput = document.getElementById('asmPartIdInput');
+    els.paramsWrap = document.getElementById('asmParamsWrap');
     els.params = document.getElementById('asmParams');
     els.pieceStatus = document.getElementById('asmPieceStatus');
     els.viewerHost = document.getElementById('asmViewer');
@@ -231,6 +232,7 @@
     return raw.map(function (entry) {
       if (!entry || typeof entry !== 'object' || typeof entry.file !== 'string') return null;
       var file = entry.file.indexOf('examples/') === 0 ? entry.file : 'examples/' + entry.file;
+      file = normalizeModelFilePath(file);
       return {
         file: file,
         title: entry.title || entry.file,
@@ -415,7 +417,8 @@
       els.partIdInput.disabled = true;
       setTransformEnabled(false);
       writeTransformInputs({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0 });
-      els.params.innerHTML = '<p>Select a piece to edit parameters.</p>';
+      els.params.innerHTML = '';
+      els.paramsWrap.hidden = true;
       setPieceStatus('', 'info');
       renderLayoutState();
       return;
@@ -426,7 +429,8 @@
     els.partIdInput.value = piece.id;
     setTransformEnabled(true);
     writeTransformInputs(piece.position, piece.rotation);
-    buildParameterUI(piece);
+    var renderedParamCount = buildParameterUI(piece);
+    els.paramsWrap.hidden = renderedParamCount === 0;
     if (piece.error) {
       setPieceStatus(errorMessage(piece.error), 'error');
     } else if (piece.loading) {
@@ -466,7 +470,7 @@
   function makePieceFromCatalog(item) {
     return {
       id: createPieceId(),
-      file: item.file,
+      file: normalizeModelFilePath(item.file),
       title: item.title,
       paramsDiff: {},
       position: { x: 0, y: 0, z: 0 },
@@ -629,13 +633,15 @@
   }
 
   async function ensureSource(piece) {
-    if (state.sourceCache[piece.file]) return state.sourceCache[piece.file];
-    if (state.sourceCachePromises[piece.file]) return state.sourceCachePromises[piece.file];
+    piece.file = normalizeModelFilePath(piece.file);
+    var file = piece.file;
+    if (state.sourceCache[file]) return state.sourceCache[file];
+    if (state.sourceCachePromises[file]) return state.sourceCachePromises[file];
 
-    state.sourceCachePromises[piece.file] = (async function () {
-      var fullUrl = new URL(piece.file, location.href).href;
-      var response = await fetch(piece.file);
-      if (!response.ok) throw new Error('Failed to load ' + piece.file + ' (' + response.status + ')');
+    state.sourceCachePromises[file] = (async function () {
+      var fullUrl = new URL(file, location.href).href;
+      var response = await fetch(file);
+      if (!response.ok) throw new Error('Failed to load ' + file + ' (' + response.status + ')');
       var source = await response.text();
 
       var paramDefinitions = [];
@@ -654,14 +660,14 @@
         paramDefinitions: paramDefinitions,
         defaultParams: defaultParams
       };
-      state.sourceCache[piece.file] = cache;
+      state.sourceCache[file] = cache;
       return cache;
     })();
 
     try {
-      return await state.sourceCachePromises[piece.file];
+      return await state.sourceCachePromises[file];
     } finally {
-      delete state.sourceCachePromises[piece.file];
+      delete state.sourceCachePromises[file];
     }
   }
 
@@ -938,13 +944,14 @@
   function buildParameterUI(piece) {
     var cache = state.sourceCache[piece.file];
     if (!cache || !cache.paramDefinitions) {
-      els.params.innerHTML = '<p>Parameters unavailable until source loads.</p>';
-      return;
+      els.params.innerHTML = '';
+      return 0;
     }
 
     var defaults = cache.defaultParams;
     var effective = getEffectiveParams(piece, defaults);
     els.params.innerHTML = '';
+    var renderedCount = 0;
 
     cache.paramDefinitions.forEach(function (definition, idx) {
       if (!definition) return;
@@ -961,7 +968,9 @@
       }
       if (!definition.name) return;
       els.params.appendChild(createParamControl(piece, definition, effective[definition.name], defaults[definition.name], idx));
+      renderedCount += 1;
     });
+    return renderedCount;
   }
 
   function renderCaption(node, caption, fallbackText) {
@@ -1159,6 +1168,7 @@
     var newPieces = payload.pieces.map(function (raw) {
       if (!raw || typeof raw !== 'object') throw new Error('Each piece must be an object.');
       if (!raw.file || typeof raw.file !== 'string') throw new Error('Each piece must include a file path.');
+      var normalizedFile = normalizeModelFilePath(raw.file);
 
       var baseId = sanitizePieceId(raw.id, 'piece');
       var uniqueId = baseId;
@@ -1171,8 +1181,8 @@
 
       return {
         id: uniqueId,
-        file: raw.file,
-        title: inferTitle(raw.file),
+        file: normalizedFile,
+        title: inferTitle(normalizedFile),
         paramsDiff: {},
         position: normalizeVector(raw.position),
         rotation: normalizeVector(raw.rotation),
@@ -1201,8 +1211,9 @@
   }
 
   function inferTitle(file) {
+    file = normalizeModelFilePath(file);
     for (var i = 0; i < state.catalog.length; i++) {
-      if (state.catalog[i].file === file) return state.catalog[i].title;
+      if (normalizeModelFilePath(state.catalog[i].file) === file) return state.catalog[i].title;
     }
     var parts = String(file).split('/');
     return parts[parts.length - 1] || file;
@@ -1226,6 +1237,11 @@
     if (value < min) return min;
     if (value > max) return max;
     return value;
+  }
+
+  function normalizeModelFilePath(file) {
+    var text = String(file || '');
+    return /\.stl$/i.test(text) ? text.replace(/\.stl$/i, '.jscad') : text;
   }
 
   function setGlobalStatus(message, kind) {


### PR DESCRIPTION
### Motivation

- Provide a standalone in-browser assembler interface for JSCAD to browse examples, add/compose parts, edit parameters/transforms, and export/import assemblies.
- Ship a self-contained runtime that integrates with the existing JSCAD engine to build solids (in-worker or main thread) and render merged assemblies in a viewer.

### Description

- Add `assembler.html` which implements the application layout and controls including toolbar, catalog, viewer panel, inspector, and import/export hooks.
- Add `assembler.css` which provides styles for the toolbar, three-column layout (`#asmLayout`), catalog/assembly lists, inspector controls, badges and responsive behavior.
- Add bundled runtime `dist/assembler.js` implementing catalog loading and parsing (`parseActiveExamplesFromIndex`), piece lifecycle (create/duplicate/remove/clear), parameter UI generation, import/export of JSON assemblies, source caching with parameter defaults, rebuild pipeline using `rebuildSolids`/`rebuildSolidsInWorker`, merge/render pipeline using `mergeSolids` and `Viewer`, transform application and selection colorization, and viewer resize handling via `ResizeObserver` and RAF.
- Implement utility functions for stable serialization (`stableStringify`), param normalization, piece id sanitization/uniqueness, safe numeric parsing, and error/status reporting.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3e574fc88331a2a02f345ca47c73)